### PR TITLE
s/;/,/ in META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
   "name" : "HTML::Parser",
   "version" : "0.1",
-  "description" : "role for HTML parsing";
+  "description" : "role for HTML parsing",
   "depends" : ["XML::Document"],
   "provides" : {
       "HTML::Parser": "lib/HTML/Parser.pm6"


### PR DESCRIPTION
Noticed this in the http://modules.perl6.org/log/update.log when I was trying to work out why one of my modules wasn't showing up
